### PR TITLE
fix: update prepack script to include prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "commitlint": "commitlint --edit",
-    "prepack": "nuxt-module-build build",
+    "prepack": "nuxt-module-build prepare && nuxt-module-build build",
     "dev": "npm run dev:prepare && nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",


### PR DESCRIPTION
see #3 

`nuxt-module-build build` requires `nuxt-module-build prepare` to be executed.